### PR TITLE
Optimize masher tech for Nauvis

### DIFF
--- a/all-the-overhaul-modpack/prototypes/recipe.lua
+++ b/all-the-overhaul-modpack/prototypes/recipe.lua
@@ -1352,13 +1352,14 @@ Recipe("5d-lab-10"):replace_ingredient("productivity-module-3", { "se-naquium-cu
 -- 01
 Recipe("5d-masher-01"):replace_ingredient("electronic-circuit", { "electric-motor", 2 })
 Recipe("5d-masher-01"):replace_ingredient("steel-plate", { "articulated-mechanism", 5 })
+Recipe("5d-masher-01"):replace_ingredient("lead-plate", { "invar-plate", 2 })
 Recipe("5d-masher-01"):add_ingredient({ "aluminum-plate", 4 })
 Recipe("5d-masher-01"):add_ingredient({ "stone-brick", 4 })
 -- 02
 Recipe("5d-masher-02"):replace_ingredient("steel-plate", { "motorized-articulator", 5 })
 Recipe("5d-masher-02"):replace_ingredient("iron-gear-wheel", { "steel-gear-wheel", 10 })
 Recipe("5d-masher-02"):add_ingredient({ "gearbox", 2 })
-Recipe("5d-masher-02"):add_ingredient({ "tungsten-plate", 4 })
+Recipe("5d-masher-02"):add_ingredient({ "diamond", 8 })
 Recipe("5d-masher-02"):add_ingredient({ "stone-brick", 4 })
 -- 03
 Recipe("5d-masher-03"):replace_ingredient("advanced-circuit", { "processing-unit", 4 })

--- a/all-the-overhaul-modpack/prototypes/technology.lua
+++ b/all-the-overhaul-modpack/prototypes/technology.lua
@@ -785,18 +785,19 @@ util.tech_add_ingredients("advanced-material-processing-11",{"kr-optimization-te
 -- 01
 data.raw.technology["5d-masher-1"].unit.count = 100
 util.tech_remove_prerequisites("5d-masher-1", {"advanced-material-processing-2"})
-util.tech_add_prerequisites("5d-masher-1",{"automation-science-pack","electricity"})
+util.tech_add_prerequisites("5d-masher-1",{"invar-processing"})
 util.tech_remove_ingredients("5d-masher-1", {"logistic-science-pack","chemical-science-pack"})
+util.tech_add_ingredients("5d-masher-1", {"basic-tech-card"})
 -- 02
 data.raw.technology["5d-masher-2"].unit.count = 200
 util.tech_remove_prerequisites("5d-masher-2", {"advanced-material-processing-3"})
-util.tech_add_prerequisites("5d-masher-2",{"tungsten-processing","mechanical-engineering"})
-util.tech_remove_ingredients("5d-masher-2", {"chemical-science-pack"})
+util.tech_add_prerequisites("5d-masher-2",{"diamond-processing"})
 -- 03
 data.raw.technology["5d-masher-3"].unit.count = 300
 util.tech_remove_prerequisites("5d-masher-3", {"advanced-material-processing-4"})
-util.tech_add_prerequisites("5d-masher-3",{"nitinol-processing", "advanced-electronics-2"})
-util.tech_remove_ingredients("5d-masher-3", {"production-science-pack","se-rocket-science-pack","space-science-pack"})
+util.tech_add_prerequisites("5d-masher-3",{"nitinol-processing", "advanced-electronics-2", "productivity-science-pack"})
+util.tech_remove_ingredients("5d-masher-3", {"production-science-pack", "space-science-pack"})
+util.tech_add_ingredients("5d-masher-3", {"productivity-science-pack"})
 -- 04
 data.raw.technology["5d-masher-4"].unit.count = 400
 util.tech_remove_prerequisites("5d-masher-4", {"production-science-pack","advanced-material-processing-5"})


### PR DESCRIPTION
I wanted to achieve a good distribution of the masher techs that are being unlocked on Nauvis. mk1 needs red, mk2 blue and mk3 pink and yellow.

This is just a proposal, so that's why a pull request.