### PR TITLE
Make use of Productivity Science Pack

### DIFF
--- a/all-the-overhaul-modpack/_prototypes/technology.lua
+++ b/all-the-overhaul-modpack/_prototypes/technology.lua
@@ -324,3 +324,15 @@ util.tech_add_ingredients("area-mining-drill", { "utility-science-pack", "se-mat
 
 util.tech_remove_prerequisites("se-processing-iridium", { "area-mining-drill" })
 util.tech_add_prerequisites("se-processing-iridium", { "kr-electric-mining-drill-mk3" })
+
+-- Use Purple Tech Cards
+
+for _, technology in pairs(data.raw.technology) do
+    if (technology.hasIngredient("automation-science-pack") 
+        and technology.hasIngredient("se-rocket-science-pack")
+        and technology.hasIngredient("chemical-science-pack")
+        and technology.hasIngredient("space-science-pack")) then
+            technology.addIngredient("productivity-science-pack")
+        end
+        
+end

--- a/all-the-overhaul-modpack/util/technology.lua
+++ b/all-the-overhaul-modpack/util/technology.lua
@@ -138,5 +138,19 @@ function atom.util.Technology(value)
                 end
             end
         end,
+
+        -- Checks technology for containing science packs
+        hasIngredient = function(ingredientName)
+            local function apply(_table)
+                for i, result in pairs(_table.unit.ingredients) do
+                    if result.name ==ingredientName then
+                        return true
+                    else
+                        return false
+                    end
+                end
+            end
+        end,
+
     }
 end


### PR DESCRIPTION
Added productivity science packs to all researches that have Space Science, Rocket Tech Cards, Chemical Tech Cards, and Automation Tech Cards.

seemed a good alternative to searching through the entire technology catalog while still appending it to the generalist techs that should require tech cards