### PR TITLE
Fix zirconium processing tech unlocks

### DIFF
--- a/all-the-overhaul-modpack/2-fixes.lua
+++ b/all-the-overhaul-modpack/2-fixes.lua
@@ -262,3 +262,11 @@ atom.util.recipe.removeIngredient("silicone")
 atom.util.item.removeByName("silicone")
 atom.util.recipe.removeIngredient("zirconium-sponge")
 atom.util.item.removeByName("zirconium-sponge")
+
+-- Fix Ziroconia (zirconium-processing in 2.0) processing tech
+local zirco_tech = Technology("zirconium-processing")
+if zirco_tech then
+    zirco_tech.addRecipe("zirconium-tungstate")
+    zirco_tech.addRecipe("zircaloy-4")
+    Technology("zirconia-processing").removeRecipe("zirconium-tungstate")
+end

--- a/all-the-overhaul-modpack/content/material-processing/materials/zirconium.lua
+++ b/all-the-overhaul-modpack/content/material-processing/materials/zirconium.lua
@@ -18,8 +18,8 @@ local config = atom.processing.util.prepareConfig({
     },
     unlockedBy = {
         oreToPlate = "zirconia-processing",
-        oreToDust = "zirconia-processing",
-        dustToIngot = "zirconia-processing",
+        oreToDust = "zirconium-processing",
+        dustToIngot = "zirconium-processing",
     }
 })
 

--- a/all-the-overhaul-modpack/integrations/5dim/lab.lua
+++ b/all-the-overhaul-modpack/integrations/5dim/lab.lua
@@ -67,7 +67,7 @@ atom.util.Recipe("gr_charger_recipe").addIngredient("kr-stabilizer-charging-stat
 -- Technologies
 
 local tech2 = atom.util.Technology("5d-lab-1")
-tech2.replacePrerequisite("engine", "zirconia-processing")
+tech2.replacePrerequisite("engine", "zirconium-processing")
 
 local tech3 = atom.util.Technology("5d-lab-2")
 tech3.addPrerequisite("nitinol-processing")


### PR DESCRIPTION
The tech zirconia-processing was replaced by zirconium-processing and zirconia-processing is now unlocked on mining zirconium so should only unlock the plate (not like it's useful I don't think)