### PR TITLE
Fixed mini machines being usable on non-electronic recipes

### DIFF
--- a/all-the-overhaul-modpack/_prototypes/common-final.lua
+++ b/all-the-overhaul-modpack/_prototypes/common-final.lua
@@ -133,4 +133,5 @@ for i = 1, 10 do
     data.raw["assembling-machine"]["mini-assembler-" .. i].crafting_speed = data.raw["assembling-machine"]["mini-assembler-" .. i].crafting_speed * 2
     data.raw["assembling-machine"]["mini-assembler-" .. i].energy_source.emissions_per_minute.pollution = data.raw["assembling-machine"]["mini-assembler-" .. i].energy_source.emissions_per_minute.pollution / 2
     data.raw["assembling-machine"]["mini-assembler-" .. i].energy_usage = (futil.parse_energy(data.raw["assembling-machine"]["mini-assembler-" .. i].energy_usage) / 2) .. "J"
+    data.raw["assembling-machine"]["mini-assembler-" .. i].localised_name = { "mini-name.mini-machine", {"", tostring(i) }}
 end

--- a/all-the-overhaul-modpack/integrations/final.lua
+++ b/all-the-overhaul-modpack/integrations/final.lua
@@ -1,3 +1,4 @@
+require("mini-machines-final")
 require("248k.final")
 
 -- Use purple tech cards more

--- a/all-the-overhaul-modpack/integrations/mini-machines-final.lua
+++ b/all-the-overhaul-modpack/integrations/mini-machines-final.lua
@@ -1,0 +1,34 @@
+local Recipe_old = require('__jalm__/stdlib/data/recipe')
+
+data.raw["assembling-machine"]["mini-assembler-1"].crafting_categories = { "electronics" }
+data.raw["assembling-machine"]["mini-assembler-2"].crafting_categories = { "electronics", "electronics-machine" }
+data.raw["assembling-machine"]["mini-assembler-3"].crafting_categories = { "electronics", "electronics-machine", "crafting-or-electromagnetics" }
+data.raw["assembling-machine"]["mini-assembler-4"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-3"].crafting_categories)
+data.raw["assembling-machine"]["mini-assembler-5"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-4"].crafting_categories)
+data.raw["assembling-machine"]["mini-assembler-6"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-5"].crafting_categories)
+data.raw["assembling-machine"]["mini-assembler-7"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-6"].crafting_categories)
+data.raw["assembling-machine"]["mini-assembler-8"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-7"].crafting_categories)
+data.raw["assembling-machine"]["mini-assembler-9"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-8"].crafting_categories)
+data.raw["assembling-machine"]["mini-assembler-10"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["mini-assembler-9"].crafting_categories)
+
+-- Set crafting categories for selected recipes
+Recipe_old("aluminum-cable"):change_category("electronics")
+Recipe_old("basic-electronic-components"):change_category("electronics")
+Recipe_old("basic-electronic-components-silver"):change_category("electronics")
+Recipe_old("kr-automation-core"):change_category("electronics")
+Recipe_old("kr-blank-tech-card"):change_category("electronics")
+Recipe_old("kr-electronic-components"):change_category("electronics-machine")
+Recipe_old("advanced-electronic-components"):change_category("electronics-machine")
+Recipe_old("gold-wire"):change_category("electronics-machine")
+Recipe_old("integrated-circuit"):change_category("electronics-machine")
+Recipe_old("tantalum-capacitor"):change_category("electronics-machine")
+Recipe_old("temperature-sensor"):change_category("electronics-machine")
+Recipe_old("mlcc"):change_category("electronics-machine")
+Recipe_old("nickel-electromagnet"):change_category("electronics-machine")
+Recipe_old("optical-fiber"):change_category("electronics-machine")
+Recipe_old("silver-wire"):change_category("electronics-machine")
+Recipe_old("tinned-cable"):change_category("electronics-machine")
+Recipe_old("advanced-cable"):change_category("electronics-machine")
+Recipe_old("advanced-processing-unit"):change_category("electronics-machine")
+Recipe_old("advanced-cable"):change_category("electronics-machine")
+Recipe_old("advanced-processing-unit"):change_category("electronics-machine")

--- a/all-the-overhaul-modpack/integrations/mini-machines.lua
+++ b/all-the-overhaul-modpack/integrations/mini-machines.lua
@@ -1,8 +1,9 @@
-local Recipe_old = require('__jalm__/stdlib/data/recipe')
+-- Changes to mini machine recipes
+-- Move category assignments to mini-machines-final.lua because mini machines
+-- overrides it in __mini-machines__/prototypes/copy-final-fixes.lua for some reason...
 
 -- 01
 local assembler1 = data.raw.recipe["mini-assembler-1"]
-assembler1.crafting_categories = { "electronics" }
 assembler1.ingredients = {
     { type = "item", name = "electric-motor", amount = 2 },
     { type = "item", name = "articulated-mechanism", amount = 2 },
@@ -12,7 +13,6 @@ assembler1.ingredients = {
 
 -- 02
 local assembler2 = data.raw.recipe["mini-assembler-2"]
-assembler2.crafting_categories = { "electronics", "electronics-machine" }
 assembler2.ingredients = {
     { type = "item", name = "mini-assembler-1", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -22,7 +22,6 @@ assembler2.ingredients = {
 
 -- 03
 local assembler3 = data.raw.recipe["mini-assembler-3"]
-assembler3.crafting_categories = { "electronics", "electronics-machine", "crafting-or-electromagnetics" }
 assembler3.ingredients = {
     { type = "item", name = "mini-assembler-2", amount = 1 },
     { type = "item", name = "solder", amount = 8 },
@@ -33,7 +32,6 @@ assembler3.ingredients = {
 
 -- 04
 local assembler4 = data.raw.recipe["mini-assembler-4"]
-assembler4.crafting_categories = table.deepcopy(assembler3.crafting_categories)
 assembler4.ingredients = {
     { type = "item", name = "mini-assembler-3", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -46,7 +44,6 @@ assembler4.ingredients = {
 
 -- 05
 local assembler5 = data.raw.recipe["mini-assembler-5"]
-assembler5.crafting_categories = table.deepcopy(assembler4.crafting_categories)
 assembler5.ingredients = {
     { type = "item", name = "mini-assembler-4", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -58,7 +55,6 @@ assembler5.ingredients = {
 
 -- 06
 local assembler6 = data.raw.recipe["mini-assembler-6"]
-assembler6.crafting_categories = table.deepcopy(assembler5.crafting_categories)
 assembler6.ingredients = {
     { type = "item", name = "mini-assembler-5", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -70,7 +66,6 @@ assembler6.ingredients = {
 
 -- 07
 local assembler7 = data.raw.recipe["mini-assembler-7"]
-assembler7.crafting_categories = table.deepcopy(assembler6.crafting_categories)
 assembler7.ingredients = {
     { type = "item", name = "mini-assembler-6", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -84,7 +79,6 @@ assembler7.ingredients = {
 
 -- 08
 local assembler8 = data.raw.recipe["mini-assembler-8"]
-assembler8.crafting_categories = table.deepcopy(assembler7.crafting_categories)
 assembler8.ingredients = {
     { type = "item", name = "mini-assembler-7", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -98,7 +92,6 @@ assembler8.ingredients = {
 
 -- 09
 local assembler9 = data.raw.recipe["mini-assembler-9"]
-assembler9.crafting_categories = table.deepcopy(assembler8.crafting_categories)
 assembler9.ingredients = {
     { type = "item", name = "mini-assembler-8", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -113,7 +106,6 @@ assembler9.ingredients = {
 
 -- 10
 local assembler10 = data.raw.recipe["mini-assembler-10"]
-assembler10.crafting_categories = table.deepcopy(assembler9.crafting_categories)
 assembler10.ingredients = {
     { type = "item", name = "mini-assembler-9", amount = 1 },
     { type = "item", name = "solder", amount = 5 },
@@ -125,26 +117,3 @@ assembler10.ingredients = {
     { type = "item", name = "se-heavy-assembly", amount = 2 },
     { type = "item", name = "se-naquium-cube", amount = 1 }
 }
-
-
--- Set crafting categories for selected recipes
-Recipe_old("aluminum-cable"):change_category("electronics")
-Recipe_old("basic-electronic-components"):change_category("electronics")
-Recipe_old("basic-electronic-components-silver"):change_category("electronics")
-Recipe_old("kr-automation-core"):change_category("electronics")
-Recipe_old("kr-blank-tech-card"):change_category("electronics")
-Recipe_old("kr-electronic-components"):change_category("electronics-machine")
-Recipe_old("advanced-electronic-components"):change_category("electronics-machine")
-Recipe_old("gold-wire"):change_category("electronics-machine")
-Recipe_old("integrated-circuit"):change_category("electronics-machine")
-Recipe_old("tantalum-capacitor"):change_category("electronics-machine")
-Recipe_old("temperature-sensor"):change_category("electronics-machine")
-Recipe_old("mlcc"):change_category("electronics-machine")
-Recipe_old("nickel-electromagnet"):change_category("electronics-machine")
-Recipe_old("optical-fiber"):change_category("electronics-machine")
-Recipe_old("silver-wire"):change_category("electronics-machine")
-Recipe_old("tinned-cable"):change_category("electronics-machine")
-Recipe_old("advanced-cable"):change_category("electronics-machine")
-Recipe_old("advanced-processing-unit"):change_category("electronics-machine")
-Recipe_old("advanced-cable"):change_category("electronics-machine")
-Recipe_old("advanced-processing-unit"):change_category("electronics-machine")

--- a/all-the-overhaul-modpack/locale/en/strings.cfg
+++ b/all-the-overhaul-modpack/locale/en/strings.cfg
@@ -13,22 +13,16 @@ t0-electrolysis-plant=Electrolysis plant MK1
 kr-electrolysis-plant=Electrolysis plant MK2
 t2-electrolysis-plant=Electrolysis plant MK3
 t3-electrolysis-plant=Electrolysis plant MK4
-mini-assembler-1=Electronics assembling machine 1
-mini-assembler-2=Electronics assembling machine 2
-mini-assembler-3=Electronics assembling machine 3
-mini-assembler-4=Electronics assembling machine 4
-mini-assembler-5=Electronics assembling machine 5
-mini-assembler-6=Electronics assembling machine 6
-mini-assembler-7=Electronics assembling machine 7
-mini-assembler-8=Electronics assembling machine 8
-mini-assembler-9=Electronics assembling machine 9
-mini-assembler-10=Electronics assembling machine 10
 fluid-furnace=Fluid Burning Furnace
 seafloor-drill-mk2=Seafloor drill MK2
 seafloor-drill-mk3=Seafloor drill MK3
 bi-cokery=Cokery MK1
 bi-cokery-2=Cokery MK2
 bi-cokery-3=Cokery MK3
+
+[mini-name]
+mini-machine=Electronics assembling machine __1__
+mini-technology=Key research for electronics assembly
 
 [entity-description]
 imersium-wall=Wall with very high damage resistance.


### PR DESCRIPTION
Cackling Fiend mentioned that the intention with mini machines was for their use to be relegated to electronics recipes but this wasn't working with the current version.
 Categories need to be assigned during final fixes because mini machines for some reason overrides changes to their machines in their final fixes.