### PR TITLE
Electrolysis plant touchup

### DIFF
--- a/all-the-overhaul-modpack/_prototypes/common-final.lua
+++ b/all-the-overhaul-modpack/_prototypes/common-final.lua
@@ -135,3 +135,6 @@ for i = 1, 10 do
     data.raw["assembling-machine"]["mini-assembler-" .. i].energy_usage = (futil.parse_energy(data.raw["assembling-machine"]["mini-assembler-" .. i].energy_usage) / 2) .. "J"
     data.raw["assembling-machine"]["mini-assembler-" .. i].localised_name = { "mini-name.mini-machine", {"", tostring(i) }}
 end
+
+data.raw["assembling-machine"]["kr-electrolysis-plant"].energy_usage = "3.125MW"
+data.raw["assembling-machine"]["kr-electrolysis-plant-spaced"].energy_usage = "3.125MW"

--- a/all-the-overhaul-modpack/_prototypes/entities/machines.lua
+++ b/all-the-overhaul-modpack/_prototypes/entities/machines.lua
@@ -13,7 +13,7 @@ data.raw["assembling-machine"]["kr-filtration-plant"].energy_usage = "625kW"
 
 data.raw["assembling-machine"]["kr-electrolysis-plant"].module_slots = 4
 data.raw["assembling-machine"]["kr-electrolysis-plant"].crafting_speed = 1.75
-data.raw["assembling-machine"]["kr-electrolysis-plant"].energy_usage = "3.125MW"
+--data.raw["assembling-machine"]["kr-electrolysis-plant"].energy_usage = "3.125MW"
 
 data.raw["assembling-machine"]["kr-advanced-furnace"].module_slots = 8
 data.raw["assembling-machine"]["kr-advanced-furnace"].crafting_speed = 384

--- a/all-the-overhaul-modpack/content/electrolysis-plant.lua
+++ b/all-the-overhaul-modpack/content/electrolysis-plant.lua
@@ -17,6 +17,7 @@ local t0_kr_electrolysis_plant = table.deepcopy(data.raw["assembling-machine"]["
 table.assign(t0_kr_electrolysis_plant, {
     name = "t0-electrolysis-plant",
     module_slots = 3,
+    allowed_effects = { "speed", "productivity", "pollution", "quality" },
     energy_usage = "2.5MW",
     crafting_speed = 1,
     next_upgrade = "kr-electrolysis-plant",
@@ -93,6 +94,7 @@ local t2_kr_electrolysis_plant = table.deepcopy(data.raw["assembling-machine"]["
 table.assign(t2_kr_electrolysis_plant, {
     name = "t2-electrolysis-plant",
     module_slots = 5,
+    allowed_effects = { "speed", "productivity", "pollution", "quality" },
     energy_usage = "4MW",
     crafting_speed = 2.5,
     next_upgrade = "t3-electrolysis-plant",
@@ -170,6 +172,7 @@ local t3_kr_electrolysis_plant = table.deepcopy(data.raw["assembling-machine"]["
 table.assign(t3_kr_electrolysis_plant, {
     name = "t3-electrolysis-plant",
     module_slots = 6,
+    allowed_effects = { "speed", "productivity", "pollution", "quality" },
     energy_usage = "5MW",
     crafting_speed = 3.75,
     se_allow_in_space = true,


### PR DESCRIPTION
Judging by the energy usage, ATOM's new electrolysis plants are intended to fit in with the balance changes SE makes to them to prevent infinite energy loops... except they don't have the changes to allowed modules, since ATOM copies them in data and SE changes them in data-final-fixes. So this fixes that.

ATOM also make the MK2 plant (internally, the original one) a bit cheaper to run, but this gets overwritten by SE. So I moved it someplace where it would work.